### PR TITLE
fix abs for SF

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -1,2 +1,0 @@
-upload_channel:
-  - sfe1ed40


### PR DESCRIPTION
quick fix, we promised this 3 weeks ago

in the previous PR https://github.com/AnacondaRecipes/sf-hamilton-feedstock/pull/1
there was no abs file (it was named erroneously `conda_build_config.yaml`)